### PR TITLE
Aboutページの移行

### DIFF
--- a/pysight/app/about/page.tsx
+++ b/pysight/app/about/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About | PySight",
+  description: "このページでは、PySight の目的や制作者の簡単な自己紹介を掲載しています。",
+  openGraph: {
+    siteName: "PySight",
+    title: "About | PySight",
+    url: "https://pysight.dev/about/",
+    description: "このページでは、PySight の目的や制作者の簡単な自己紹介を掲載しています。",
+    type: "website",
+    images: [{ url: "https://pysight.dev/assets/pysight-summary.png" }],
+  },
+  twitter: {
+    card: "summary",
+    title: "About | PySight",
+    description: "このページでは、PySight の目的や制作者の簡単な自己紹介を掲載しています。",
+    images: ["https://pysight.dev/assets/pysight-summary.png"],
+  },
+  alternates: {
+    canonical: "https://pysight.dev/about/",
+  },
+};
+
+function About() {
+  return (
+    <main className="max-w-[760px] mx-auto px-6 py-10 prose">
+      <h1>作者について</h1>
+      <p>こんにちは、totosuki です。</p>
+      <p>音楽とプログラミングとPythonが好きです。</p>
+      <p>
+        <span className="font-heading">PySight</span>{" "}
+        は、私の個人ホームページ兼、Python に関する知見をまとめたサイトです。
+      </p>
+      <p>
+        GitHub（
+        <a href="https://github.com/totosuki" target="_blank" rel="noopener noreferrer">
+          @totosuki
+        </a>
+        ）X（
+        <a href="https://x.com/totosuki_" target="_blank" rel="noopener noreferrer">
+          @totosuki_
+        </a>
+        ）でも活動しています。感想などあれば気軽にどうぞ！
+      </p>
+
+      <h1><span className="font-heading">PySight</span> について</h1>
+      <p>
+        <span className="font-heading">PySight</span>{" "}
+        では、公式ドキュメントだけでは掴みにくい Python の仕様や内部の仕組みについて、調査・実験した結果を記事としてまとめています。
+      </p>
+      <p>ちょっとマニアックだけど、読み物としても楽しめる内容を目指しています。</p>
+
+      <h1>注意点</h1>
+      <p>
+        記事を掲載するにあたり、情報の精査をしてはいますが完璧ではありません。あくまでも参考程度にご覧ください。
+      </p>
+      <p>
+        なお、記事の内容は気づいた点や検証結果の変化に応じて、予告なく修正・更新されることがあります。
+      </p>
+    </main>
+  );
+}
+
+export default About;

--- a/pysight/app/globals.css
+++ b/pysight/app/globals.css
@@ -11,4 +11,37 @@
     --btn: #dddddd;
     --quote-content: #bbbbbb;
     --quote-author: #888888;
+    --link: #3b82f6;
+}
+
+/* ========== Prose (記事・コンテンツ共通) ========== */
+.prose {
+    line-height: 1.8;
+}
+
+.prose h1 {
+    font-size: 1.6rem;
+    font-weight: 700;
+    margin-top: 2.5rem;
+    margin-bottom: 1rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.prose h1:first-child {
+    margin-top: 0;
+}
+
+.prose p {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.prose a {
+    color: var(--link);
+    text-decoration: underline;
+}
+
+.prose a:hover {
+    text-decoration: none;
 }


### PR DESCRIPTION
## Summary
- `app/about/page.tsx` を新規作成し、レガシー版と同内容のAboutページを実装
- `globals.css` に `.prose` クラスを追加（`h1`・`p`・`a` のスタイル）。将来のMarkdown動的ページでも共通利用できる形に設計

## Test plan
- [x] `/about/` にアクセスして「作者について」「PySightについて」「注意点」の3セクションが表示されること
- [x] GitHubおよびXへのリンクが新しいタブで開くこと
- [x] `npm run build` が正常完了すること

closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)