### PR TITLE
ダークモード・ライトモードの実装

### DIFF
--- a/pysight/app/globals.css
+++ b/pysight/app/globals.css
@@ -12,6 +12,50 @@
     --quote-content: #bbbbbb;
     --quote-author: #888888;
     --link: #3b82f6;
+    --card: #dddddd;
+    --card-border: #444444;
+}
+
+/* ========== ライトモード ========== */
+.light {
+    --bg: #ffffff;
+    --fg: #222222;
+    --border: #dddddd;
+    --btn: #222222;
+    --quote-content: #555555;
+    --quote-author: #666666;
+    --link: #3b82f6;
+    --card: #333333;
+    --card-border: #d5d5d5;
+}
+
+/* ========== テーマトグルボタン ========== */
+.theme-toggle {
+    width: 46px;
+    height: 26px;
+    border-radius: 13px;
+    border: 1px solid var(--border);
+    background: var(--fg);
+    cursor: pointer;
+    position: relative;
+    transition: background 0.3s ease, border-color 0.3s ease;
+    flex-shrink: 0;
+}
+
+.theme-toggle::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--bg);
+    transition: transform 0.3s ease;
+}
+
+.light .theme-toggle::after {
+    transform: translateX(20px);
 }
 
 /* ========== Prose (記事・コンテンツ共通) ========== */

--- a/pysight/app/layout.tsx
+++ b/pysight/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Navbar from "@/components/Navbar";
+import Providers from "@/components/Providers";
 import { firaCode, notoSansJP, spaceGrotesk } from "@/lib/fonts";
 import "./globals.css";
 
@@ -11,12 +12,15 @@ export const metadata: Metadata = {
 function RootLayout({ children }: Readonly<{children: React.ReactNode;}>) {
   return (
     <html
-      lang="en"
+      lang="ja"
       className={`${notoSansJP.variable} ${spaceGrotesk.variable} ${firaCode.variable}`}
+      suppressHydrationWarning
     >
       <body className="bg-(--bg) text-(--fg)">
-        <Navbar />
-        {children}
+        <Providers>
+          <Navbar />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/pysight/components/Navbar.tsx
+++ b/pysight/components/Navbar.tsx
@@ -1,4 +1,5 @@
 import { SiGithub } from "react-icons/si";
+import ThemeToggle from "./ThemeToggle";
 
 function Navbar() {
   return (
@@ -10,6 +11,7 @@ function Navbar() {
         <a href="https://github.com/totosuki" target="_blank" aria-label="GitHubを開く" rel="noopener noreferrer">
           <SiGithub size={24} />
         </a>
+        <ThemeToggle />
       </div>
     </div>
   );

--- a/pysight/components/Providers.tsx
+++ b/pysight/components/Providers.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ThemeProvider } from 'next-themes';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="dark" themes={['dark', 'light']}>
+      {children}
+    </ThemeProvider>
+  );
+}

--- a/pysight/components/ThemeToggle.tsx
+++ b/pysight/components/ThemeToggle.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return <div className="w-[46px] h-[26px]" aria-hidden />;
+  }
+
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="theme-toggle"
+      aria-label={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
+    />
+  );
+}

--- a/pysight/package-lock.json
+++ b/pysight/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-icons": "^5.5.0"
@@ -1431,6 +1432,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/pysight/package.json
+++ b/pysight/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-icons": "^5.5.0"


### PR DESCRIPTION
## Summary
- `next-themes` を導入しテーマ管理の基盤を構築。`themes` 配列で将来の複数テーマ追加に対応できる設計
- `components/Providers.tsx` — `ThemeProvider` をラップするクライアントコンポーネント。`attribute="class"` でHTMLに `.dark` / `.light` クラスを付与
- `components/ThemeToggle.tsx` — ピル形状のトグルボタン（legacy版と同デザイン）。`useTheme` フックでテーマ切り替え、ハイドレーション前は同サイズのプレースホルダーを表示してレイアウトシフトを防止
- `components/Navbar.tsx` — `ThemeToggle` を追加
- `app/globals.css` — `.light` クラスのCSS変数を追加し全ページの配色をライトモードに対応。`--card`, `--card-border` 変数も追加
- `app/layout.tsx` — `Providers` でラップ、`suppressHydrationWarning` を追加、`lang="ja"` に修正

## Test plan
- [x] デフォルトがダークモードで表示されること
- [x] Navbarのトグルボタンを押すとライトモードに切り替わること
- [x] ページをリロードしてもテーマが保持されること（localStorage）
- [x] `npm run build` が正常完了すること

closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)