### PR TITLE
TOCをビルド時に生成する仕組みの実装

### DIFF
--- a/pysight/app/articles/[slug]/page.tsx
+++ b/pysight/app/articles/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getArticleBySlug, getArticleSlugs } from "@/lib/articles";
+import Toc from "@/components/Toc";
 
 export function generateStaticParams() {
   return getArticleSlugs().map((slug) => ({ slug }));
@@ -45,11 +46,25 @@ export default async function ArticlePage({
   const article = await getArticleBySlug(slug);
 
   return (
-    <main className="max-w-[760px] mx-auto px-6 py-10">
-      <article
-        className="prose"
-        dangerouslySetInnerHTML={{ __html: article.contentHtml }}
-      />
-    </main>
+    <div className="max-w-[1100px] mx-auto px-6 py-10 lg:flex lg:gap-12">
+      <aside className="hidden lg:block w-[220px] flex-shrink-0">
+        <div className="sticky top-[95px]">
+          <Toc toc={article.toc} />
+        </div>
+      </aside>
+
+      <main className="flex-1 min-w-0">
+        {/* モバイル向けTOC */}
+        {article.toc.length > 0 && (
+          <div className="lg:hidden mb-8 p-4 border border-(--border) rounded-lg">
+            <Toc toc={article.toc} />
+          </div>
+        )}
+        <article
+          className="prose"
+          dangerouslySetInnerHTML={{ __html: article.contentHtml }}
+        />
+      </main>
+    </div>
   );
 }

--- a/pysight/components/Toc.tsx
+++ b/pysight/components/Toc.tsx
@@ -1,0 +1,25 @@
+import type { TocEntry } from '@/lib/articles';
+
+const INDENT: Record<number, string> = { 1: '', 2: 'pl-3', 3: 'pl-6', 4: 'pl-9' };
+
+export default function Toc({ toc }: { toc: TocEntry[] }) {
+  if (toc.length === 0) return null;
+
+  return (
+    <nav aria-label="目次">
+      <p className="font-bold text-sm mb-3 text-(--fg)">目次</p>
+      <ul className="text-sm flex flex-col gap-1">
+        {toc.map((entry) => (
+          <li key={entry.id} className={INDENT[entry.depth] ?? 'pl-9'}>
+            <a
+              href={`#${entry.id}`}
+              className="text-(--quote-content) hover:text-(--fg) transition-colors duration-150 leading-snug block"
+            >
+              {entry.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/pysight/lib/__tests__/articles.test.ts
+++ b/pysight/lib/__tests__/articles.test.ts
@@ -131,7 +131,7 @@ describe('getArticleBySlug', () => {
       description: '記事Aの説明',
       date: '2024-06-01',
     });
-    expect(article.contentHtml).toContain('<h1>');
+    expect(article.contentHtml).toContain('<h1');
     expect(article.contentHtml).toContain('本文テキスト');
   });
 
@@ -152,5 +152,88 @@ describe('getArticleBySlug', () => {
     const article = await getArticleBySlug('article-b');
 
     expect(typeof article.contentHtml).toBe('string');
+  });
+
+  it('tocが含まれる', async () => {
+    mockedFs.readFileSync.mockReturnValue(FRONTMATTER_A);
+
+    const { getArticleBySlug } = await import('../articles');
+    const article = await getArticleBySlug('article-a');
+
+    expect(Array.isArray(article.toc)).toBe(true);
+  });
+});
+
+describe('extractToc', () => {
+  it('h1見出しを抽出する', async () => {
+    const { extractToc } = await import('../articles');
+    const toc = extractToc('# はじめに\n\n本文。\n');
+
+    expect(toc).toHaveLength(1);
+    expect(toc[0]).toMatchObject({ text: 'はじめに', depth: 1 });
+  });
+
+  it('複数の見出しを順序通りに抽出する', async () => {
+    const { extractToc } = await import('../articles');
+    const content = '# 概要\n\n## 詳細\n\n### 補足\n\n## まとめ\n';
+    const toc = extractToc(content);
+
+    expect(toc).toHaveLength(4);
+    expect(toc.map((e) => e.depth)).toEqual([1, 2, 3, 2]);
+    expect(toc.map((e) => e.text)).toEqual(['概要', '詳細', '補足', 'まとめ']);
+  });
+
+  it('各エントリにid文字列が付与される', async () => {
+    const { extractToc } = await import('../articles');
+    const toc = extractToc('# Hello World\n');
+
+    expect(typeof toc[0].id).toBe('string');
+    expect(toc[0].id.length).toBeGreaterThan(0);
+  });
+
+  it('重複した見出しテキストのIDが重複しない', async () => {
+    const { extractToc } = await import('../articles');
+    const toc = extractToc('# 概要\n\n## 概要\n');
+
+    expect(toc[0].id).not.toBe(toc[1].id);
+  });
+
+  it('インラインコードを含む見出しのテキストを正しく抽出する', async () => {
+    const { extractToc } = await import('../articles');
+    const toc = extractToc('# `__doc__` について\n');
+
+    expect(toc[0].text).toBe('__doc__ について');
+  });
+
+  it('太字を含む見出しのテキストを正しく抽出する', async () => {
+    const { extractToc } = await import('../articles');
+    const toc = extractToc('# **重要**なポイント\n');
+
+    expect(toc[0].text).toBe('重要なポイント');
+  });
+
+  it('コードブロック内のシャープ記号を見出しとして誤認識しない', async () => {
+    const { extractToc } = await import('../articles');
+    const content = '# 本物の見出し\n\n```python\n# コメント\n```\n';
+    const toc = extractToc(content);
+
+    expect(toc).toHaveLength(1);
+    expect(toc[0].text).toBe('本物の見出し');
+  });
+
+  it('見出しがない場合は空配列を返す', async () => {
+    const { extractToc } = await import('../articles');
+    const toc = extractToc('見出しのない本文テキスト。\n');
+
+    expect(toc).toEqual([]);
+  });
+
+  it('h5以上の見出しは含めない', async () => {
+    const { extractToc } = await import('../articles');
+    const content = '# h1\n## h2\n### h3\n#### h4\n##### h5\n###### h6\n';
+    const toc = extractToc(content);
+
+    expect(toc.every((e) => e.depth <= 4)).toBe(true);
+    expect(toc).toHaveLength(4);
   });
 });

--- a/pysight/lib/articles.ts
+++ b/pysight/lib/articles.ts
@@ -5,9 +5,19 @@ import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkGfm from 'remark-gfm';
 import remarkRehype from 'remark-rehype';
+import rehypeSlug from 'rehype-slug';
 import rehypeStringify from 'rehype-stringify';
+import { visit } from 'unist-util-visit';
+import GithubSlugger from 'github-slugger';
+import type { Root, Heading, PhrasingContent } from 'mdast';
 
 const ARTICLES_DIR = path.join(process.cwd(), 'content/articles');
+
+export type TocEntry = {
+  id: string;
+  text: string;
+  depth: 1 | 2 | 3 | 4;
+};
 
 export type ArticleMeta = {
   slug: string;
@@ -18,7 +28,35 @@ export type ArticleMeta = {
 
 export type Article = ArticleMeta & {
   contentHtml: string;
+  toc: TocEntry[];
 };
+
+/** 見出しノードからテキストを再帰的に抽出する */
+function extractHeadingText(children: PhrasingContent[]): string {
+  return children
+    .map((child) => {
+      if (child.type === 'text' || child.type === 'inlineCode') return child.value;
+      if ('children' in child) return extractHeadingText(child.children as PhrasingContent[]);
+      return '';
+    })
+    .join('');
+}
+
+/** Markdownコンテンツから見出し一覧を抽出する */
+export function extractToc(content: string): TocEntry[] {
+  const tree = unified().use(remarkParse).use(remarkGfm).parse(content) as Root;
+  const slugger = new GithubSlugger();
+  const toc: TocEntry[] = [];
+
+  visit(tree, 'heading', (node: Heading) => {
+    if (node.depth > 4) return;
+    const text = extractHeadingText(node.children as PhrasingContent[]);
+    const id = slugger.slug(text);
+    toc.push({ id, text, depth: node.depth as 1 | 2 | 3 | 4 });
+  });
+
+  return toc;
+}
 
 /** すべての記事のスラッグ一覧を返す（静的生成用） */
 export function getArticleSlugs(): string[] {
@@ -54,10 +92,13 @@ export async function getArticleBySlug(slug: string): Promise<Article> {
   const fileContents = fs.readFileSync(filePath, 'utf8');
   const { data, content } = matter(fileContents);
 
+  const toc = extractToc(content);
+
   const processedContent = await unified()
     .use(remarkParse)
     .use(remarkGfm)
     .use(remarkRehype)
+    .use(rehypeSlug)
     .use(rehypeStringify)
     .process(content);
 
@@ -69,5 +110,6 @@ export async function getArticleBySlug(slug: string): Promise<Article> {
     description: data.description as string,
     date: data.date as string,
     contentHtml,
+    toc,
   };
 }

--- a/pysight/package-lock.json
+++ b/pysight/package-lock.json
@@ -8,17 +8,20 @@
       "name": "pysight",
       "version": "0.1.0",
       "dependencies": {
+        "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "next": "16.1.6",
         "next-themes": "^0.4.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-icons": "^5.5.0",
+        "rehype-slug": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
-        "unified": "^11.0.5"
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1952,6 +1955,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1984,6 +1993,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-html": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
@@ -2001,6 +2023,19 @@
         "space-separated-tokens": "^2.0.0",
         "stringify-entities": "^4.0.0",
         "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3447,6 +3482,23 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-stringify": {

--- a/pysight/package.json
+++ b/pysight/package.json
@@ -10,17 +10,20 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "next": "16.1.6",
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-icons": "^5.5.0",
+    "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- `lib/articles.ts` に `extractToc(content)` 関数を追加
  - `unist-util-visit` で remark AST を走査し見出しノードを抽出
  - `github-slugger` で `rehype-slug` と同一の ID を生成（アンカーリンクと一致）
  - インラインコード・太字など複合ノードのテキストを再帰的に取得
  - `getArticleBySlug` の戻り値に `toc: TocEntry[]` を追加
- `rehype-slug` を unified パイプラインに追加し HTML 見出しに ID を付与
- `components/Toc.tsx` を新規作成。見出しの depth に応じてインデントを変化させる
- `app/articles/[slug]/page.tsx` に TOC サイドバーを追加（デスクトップ: sticky サイドバー / モバイル: 記事上部に表示）
- `lib/__tests__/articles.test.ts` に `extractToc` のテスト8件を追加（計18件）

## Test plan
- [x] `npm test` が18件全通過すること
- [x] `/articles/constants/` にアクセスして左サイドバーに目次が表示されること
- [x] 目次のリンクをクリックすると対応する見出しへスクロールすること
- [x] `npm run build` が正常完了すること

closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)